### PR TITLE
Feat: create promise-based xhr fetch module for restful request polling

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
         "mocha": true
     },
     "globals": {
-        "expect": true
+        "expect": true,
+        "server": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4986,6 +4986,12 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
+    "r-server": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/r-server/-/r-server-1.0.1.tgz",
+      "integrity": "sha512-upWzIgFFvAtrNndF6MX0pHDmcLP7O9OwUkaKfTNa8jGHA2X/ueeDLvDh5jMpplA6Vx4WlN3cQtREKbfP0/hJLg==",
+      "dev": true
+    },
     "randomatic": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "commit": "git-cz",
-    "lint": "eslint ./src --fix",
+    "lint": "eslint ./src/** --fix",
     "test": "BABEL_ENV=test nyc mocha --recursive",
     "watch-test": "npm run test -- -w"
   },
@@ -28,7 +28,8 @@
     "istanbul": "0.4.5",
     "jsdom": "11.12.0",
     "mocha": "5.2.0",
-    "nyc": "12.0.2"
+    "nyc": "12.0.2",
+    "r-server": "1.0.1"
   },
   "czConfig": {
     "path": "node_modules/cz-conventional-changelog"
@@ -39,7 +40,7 @@
       "./test/setup.js"
     ],
     "include": [
-      "src/modules/*.js"
+      "src/modules/**/*.js"
     ]
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,1 @@
+require('./server/app.js').listen();

--- a/server/app.js
+++ b/server/app.js
@@ -6,4 +6,25 @@ app.get('/', (req, res) => {
     res.end('Hello World');
 });
 
+//prolong request
+app.get('prolong-response', () => {
+    //do nothing
+});
+
+//report request header
+app.all('report-header/{header}', (request, response, header) => {
+    response.writeHead(200, {
+        'Content-Type': 'text/plain'
+    });
+    response.end(request.headers[header]);
+});
+
+//report query
+app.all('report-query', (request, response) => {
+    response.writeHead(200, {
+        'Content-Type': 'text/json'
+    });
+    response.end(JSON.stringify(request.query));
+});
+
 module.exports = app;

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,9 @@
+let rServer = require('r-server'),
+    app = rServer.instance();
+
+//send hello world message
+app.get('/', (req, res) => {
+    res.end('Hello World');
+});
+
+module.exports = app;

--- a/server/app.js
+++ b/server/app.js
@@ -16,7 +16,7 @@ app.all('report-header/{header}', (request, response, header) => {
     response.writeHead(200, {
         'Content-Type': 'text/plain'
     });
-    response.end(request.headers[header]);
+    response.end(request.headers[header] || 'undefined');
 });
 
 //report query
@@ -25,6 +25,74 @@ app.all('report-query', (request, response) => {
         'Content-Type': 'text/json'
     });
     response.end(JSON.stringify(request.query));
+});
+
+//perform a server action
+app.post('user/create', (request, response) => {
+    response.writeHead(201, 'User created', {
+        'Content-Location': '/user/1'
+    });
+    response.end();
+});
+
+//send incorrect content type header
+app.get('send-incorrect-content-type/{entity}', (request, response, entity) => {
+    let data = '';
+    switch(entity) {
+        case 'json':
+            data = JSON.stringify({message: 'I still parsed it'});
+            break;
+    }
+    response.writeHead(200, 'data sent', {
+        'Content-Type': 'text/plain'
+    });
+    response.end(data);
+});
+
+//send invalid content
+app.get('send-invalid-content/{entity}', (request, response, entity) => {
+    let data = '',
+        contentType = 'text/plain';
+    switch(entity) {
+        case 'json':
+            contentType = 'application/json';
+            data = '{"name": wrong-string, not placed in double quotes}';
+            break;
+    }
+    response.writeHead(200, 'data sent', {
+        'Content-Type': contentType
+    });
+    response.end(data);
+});
+
+//send content
+app.get('send-content/{entity}', (request, response, entity) => {
+    let data = '',
+        contentType = 'text/plain';
+    switch(entity) {
+        case 'html':
+            contentType = 'text/html';
+            data = 'Hello World';
+            break;
+    }
+    response.writeHead(200, 'data sent', {
+        'Content-Type': contentType
+    });
+    response.end(data);
+});
+
+//send content
+app.get('send-response-code/{int:code}', (request, response, responseCode) => {
+    response.statusCode = responseCode;
+    response.end();
+});
+
+//report request method
+app.all('report/request-method', (request, response) => {
+    response.writeHead(200, {
+        'X-Request-Method': request.method
+    });
+    response.end();
 });
 
 module.exports = app;

--- a/src/modules/Xhr.js
+++ b/src/modules/Xhr.js
@@ -1,0 +1,53 @@
+/**
+ * the xhr module performs request related tasks, manages request queues, progress watch,
+ * request headers and lots more
+ *@module Xhr
+*/
+import Queue from './Queue.js';
+
+/**
+ *@name xhrStates
+ *@private
+*/
+let xhrStates = {
+
+    /**
+     * default request timeout value.
+    */
+    timeoutAfter: 15000,
+
+    /**
+     * boolean value to indicate if manager has been started
+    */
+    started: false,
+
+    /**
+     * time in milliseconds to poll requests in a repeating circle
+    */
+    pollAfter: 250,
+
+    /**
+     * this is the number of milliseconds a request will stay and its priority level will be
+     * promoted
+    */
+    promoteAfter: 3000,
+
+    /**
+     * pending requests
+    */
+    pendingRequests: new Queue(null, true, false, (one, two) => {
+        return Queue.fnSort(one.priority, two.priority);
+    }),
+
+    /**
+     * active requests
+    */
+    activeRequests: new Queue(null, false),
+
+    /**
+     * global headers
+    */
+    globalHeaders: {
+
+    }
+};

--- a/src/modules/Xhr.js
+++ b/src/modules/Xhr.js
@@ -136,6 +136,39 @@ let xhrStates = {
 
         xhrStates.iterationId = setTimeout(manage, xhrStates.pollAfter);
         xhrStates.started = true;
+    },
+
+    /**
+     * asynchronously execute a http request on the given url using a given http method verb.
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@param {string} [options.method] - http method verb to use
+     *@param {Object|FormData} [options.data] - an object literal or form data containing
+     * request data to send
+     *@param {Object} [options.headers] - an object of http headers to send
+     *@param {string} [options.responseType] - string denoting expected response mime type
+     *@param {string} [options.contentType] - string denoting request content type
+     *@param {string} [options.cache] - request cache directive, default, no-cache or reload
+     *@param {number} [options.timeout] - time in milliseconds to abort request
+     *@param {number} [options.priority] - request priority level. priority is higher in descending order
+     *@param {Function} [options.progress] - request onprogress event callback handler
+     *@param {string} [overrideMethod] - http method verb to use, overrides options method value
+     *@returns {Promise}
+    */
+    fetch = function(url, options, overrideMethod) {
+        options = Util.isPlainObject(options)? options : {};
+
+        options.globalHeaders = xhrStates.globalHeaders;
+        options.overrideMethod = overrideMethod;
+        options.timeoutAfter = xhrStates.timeoutAfter;
+
+        return new Promise((resolve, reject) => {
+            let request = new _Request(url, options, resolve, reject, Transport.create());
+            request.age = 0;
+            request.active = false;
+            xhrStates.pendingRequests.put(request);
+            start();
+        });
     };
 
 export default {
@@ -282,5 +315,17 @@ export default {
             this.removeHeader(headerName);
 
         return this;
+    },
+
+    /**
+     * asynchronously execute a http request on the given url using a given http method verb.
+     *
+     *@memberof Xhr
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@returns {Promise}
+    */
+    fetch(url, options) {
+        return fetch(url, options);
     },
 };

--- a/src/modules/Xhr.js
+++ b/src/modules/Xhr.js
@@ -7,6 +7,7 @@ import {install, uninstall} from './Globals.js';
 import Util from './Util.js';
 import Queue from './Queue.js';
 import Transport from './Xhr/Transport.js';
+import _Request from './Xhr/Request.js';
 import _Response from './Xhr/Response.js';
 
 /**
@@ -227,5 +228,59 @@ export default {
     */
     get ieString() {
         return Transport.ieString;
+    },
+
+    /**
+     * adds a http header to the global header object.
+     *
+     *@memberof Xhr
+     *@param {string} name - the header name
+     *@param {*} value - the header value
+     *@returns {this}
+    */
+    addHeader(name, value) {
+        name = name.toString().trim();
+        xhrStates.globalHeaders[name] = value;
+        return this;
+    },
+
+    /**
+     * adds http headers to the global header object.
+     *
+     *@memberof Xhr
+     *@param {Object} entries - the header entries
+     *@returns {this}
+    */
+    addHeaders(entries) {
+        for (const [name, value] of Object.entries(entries))
+            this.addHeader(name, value);
+        return this;
+    },
+
+    /**
+     * removes http header from the global header object.
+     *
+     *@memberof Xhr
+     *@param {string} headerName - global header to remove
+     *@returns {this}
+    */
+    removeHeader(headerName) {
+        headerName = headerName.toString().trim();
+        delete xhrStates.globalHeaders[headerName];
+        return this;
+    },
+
+    /**
+     * removes comma separated list of headers from the global header object.
+     *
+     *@memberof Xhr
+     *@param {...string} headerNames - comma separated list of headers to remove
+     *@returns {this}
+    */
+    removeHeaders(...headerNames) {
+        for (let headerName of headerNames)
+            this.removeHeader(headerName);
+
+        return this;
     },
 };

--- a/src/modules/Xhr.js
+++ b/src/modules/Xhr.js
@@ -142,17 +142,6 @@ let xhrStates = {
      * asynchronously execute a http request on the given url using a given http method verb.
      *@param {string} url - the resource url
      *@param {Object} [options] - optional request configuration object
-     *@param {string} [options.method] - http method verb to use
-     *@param {Object|FormData} [options.data] - an object literal or form data containing
-     * request data to send
-     *@param {Object} [options.headers] - an object of http headers to send
-     *@param {string} [options.responseType] - string denoting expected response mime type
-     *@param {string} [options.contentType] - string denoting request content type
-     *@param {string} [options.cache] - request cache directive, default, no-cache or reload
-     *@param {number} [options.timeout] - time in milliseconds to abort request
-     *@param {number} [options.priority] - request priority level. priority is higher in descending order
-     *@param {Function} [options.progress] - request onprogress event callback handler
-     *@param {string} [overrideMethod] - http method verb to use, overrides options method value
      *@returns {Promise}
     */
     fetch = function(url, options, overrideMethod) {

--- a/src/modules/Xhr.js
+++ b/src/modules/Xhr.js
@@ -3,7 +3,10 @@
  * request headers and lots more
  *@module Xhr
 */
+import {install, uninstall} from './Globals.js';
+import Util from './Util.js';
 import Queue from './Queue.js';
+import Transport from './Xhr/Transport.js';
 import _Response from './Xhr/Response.js';
 
 /**
@@ -133,3 +136,96 @@ let xhrStates = {
         xhrStates.iterationId = setTimeout(manage, xhrStates.pollAfter);
         xhrStates.started = true;
     };
+
+export default {
+
+    /**
+     * calls the Globals install method with the parameters. This is useful when using the
+     * Utils module as a standalone distribution or lib.
+     *
+     *@param {Object} hostParam - the host object, the global this object in a given usage
+     * environment
+     *@param {Object} rootParam - the root object. an example is the document object
+     *@returns {boolean}
+    */
+    install(hostParam, rootParam) {
+        return install(hostParam, rootParam);
+    },
+
+    /**
+     * calls the Globals uninstall method with the parameters. This is useful when using the
+     * Utils module as a standalone distribution or lib.
+     *
+     *@returns {boolean}
+    */
+    uninstall() {
+        return uninstall();
+    },
+
+    /**
+     * sets default request timeout or retrieves the default timeout value
+     * the default timeout value is 15 seconds which is 15000 ms
+     *@memberof Xhr
+     *@param {number} [ms] - time in milliseconds after which to timeout request
+     *@returns {*}
+    */
+    timeoutAfter(ms) {
+        if (!Util.isNumber(ms))
+            return xhrStates.timeoutAfter;
+
+        xhrStates.timeoutAfter = ms;
+        return this;
+    },
+
+    /**
+     * sets the polling time or retrieves the poll time value.
+     * The default value is 250ms
+     *@memberof Xhr
+     *@param {number} [ms] - time in milliseconds after which to poll requests repeatedly
+     *@returns {*}
+    */
+    pollAfter(ms) {
+        if (!Util.isNumber(ms))
+            return xhrStates.pollAfter;
+
+        xhrStates.pollAfter = ms;
+        return this;
+    },
+
+    /**
+     * sets time after which a pending request priority is promoted one value up or returns
+     * the value if called with no ms argument.
+     * The default value is 3000ms
+     *@memberof Xhr
+     *@param {number} ms - time in milliseconds after which to promote a request's priority
+     *@returns {*}
+    */
+    promoteAfter(ms) {
+        if (!Util.isNumber(ms))
+            return xhrStates.promoteAfter;
+
+        xhrStates.promoteAfter = ms;
+        return this;
+    },
+
+    /**
+     * indicates if xml http request is supported
+     *
+     *@memberof Xhr
+     *@type {boolean}
+    */
+    get supported() {
+        return Transport.supported;
+    },
+
+    /**
+     * contains the  ActiveXObject MSXML version string used in creating xhr transport.
+     * Its value will be empty if created through the XMLHttpRequest construct
+     *
+     *@memberof Xhr
+     *@type {string}
+    */
+    get ieString() {
+        return Transport.ieString;
+    },
+};

--- a/src/modules/Xhr.js
+++ b/src/modules/Xhr.js
@@ -4,6 +4,7 @@
  *@module Xhr
 */
 import Queue from './Queue.js';
+import _Response from './Xhr/Response.js';
 
 /**
  *@name xhrStates
@@ -11,43 +12,124 @@ import Queue from './Queue.js';
 */
 let xhrStates = {
 
-    /**
-     * default request timeout value.
-    */
-    timeoutAfter: 15000,
+        /**
+         * default request timeout value.
+        */
+        timeoutAfter: 15000,
+
+        /**
+         * boolean value to indicate if manager has been started
+        */
+        started: false,
+
+        /**
+         * time in milliseconds to poll requests in a repeating circle
+        */
+        pollAfter: 250,
+
+        /**
+         * this is the number of milliseconds a request will stay and its priority level will be
+         * promoted
+        */
+        promoteAfter: 3000,
+
+        /**
+         * pending requests
+        */
+        pendingRequests: new Queue(null, true, false, (one, two) => {
+            return Queue.fnSort(one.priority, two.priority);
+        }),
+
+        /**
+         * active requests
+        */
+        activeRequests: new Queue(null, false),
+
+        /**
+         * global headers
+        */
+        globalHeaders: {
+
+        }
+    },
 
     /**
-     * boolean value to indicate if manager has been started
+     *@private
+     * checks for request that have completed, initaiting the appropriate callback
     */
-    started: false,
+    checkActiveRequests = function () {
+        xhrStates.activeRequests.forEach(function(request, idx, queue) {
+            if (request.state === 'complete') {
+                queue.deleteIndex(idx);
+
+                let response = new _Response(request);
+                if (response.ok)
+                    request.resolve(response);
+                else
+                    request.reject(response);
+            }
+        });
+    },
 
     /**
-     * time in milliseconds to poll requests in a repeating circle
+     *@private
+     * executes next request
     */
-    pollAfter: 250,
+    executeNextRequest = function () {
+        let activeRequests = xhrStates.activeRequests,
+            pendingRequests = xhrStates.pendingRequests;
+
+        while(activeRequests.length < 4 && pendingRequests.length > 0) {
+            let request = pendingRequests.shift();
+
+            request.send();
+
+            request.stayed = 0;
+            activeRequests.put(request);
+        }
+    },
 
     /**
-     * this is the number of milliseconds a request will stay and its priority level will be
-     * promoted
+     *@private
+     * promotes the priority of each pending request that have lasted for ageLimit
     */
-    promoteAfter: 3000,
+    promote = function () {
+        var pendingRequests = xhrStates.pendingRequests;
+        pendingRequests.forEach((request) => {
+            request.age += xhrStates.pollAfter;
+            if (request.age >= xhrStates.promoteAfter) {
+                request.age = 0;
+                request.priority -= 1;
+            }
+        });
+        pendingRequests.sort();
+    },
 
     /**
-     * pending requests
+     *@private
+     * manages the polling process.
     */
-    pendingRequests: new Queue(null, true, false, (one, two) => {
-        return Queue.fnSort(one.priority, two.priority);
-    }),
+    manage = function() {
+        clearTimeout(xhrStates.iterationId);
+
+        promote();
+        executeNextRequest();
+        checkActiveRequests();
+
+        if (xhrStates.pendingRequests.length > 0 || xhrStates.activeRequests.length > 0)
+            xhrStates.iterationId = setTimeout(manage, xhrStates.pollAfter);
+        else
+            xhrStates.started = false;
+    },
 
     /**
-     * active requests
+     *@private
+     * starts the polling processing.
     */
-    activeRequests: new Queue(null, false),
+    start = function() {
+        if (xhrStates.started)
+            return;
 
-    /**
-     * global headers
-    */
-    globalHeaders: {
-
-    }
-};
+        xhrStates.iterationId = setTimeout(manage, xhrStates.pollAfter);
+        xhrStates.started = true;
+    };

--- a/src/modules/Xhr.js
+++ b/src/modules/Xhr.js
@@ -328,4 +328,76 @@ export default {
     fetch(url, options) {
         return fetch(url, options);
     },
+
+    /**
+     * get data asynchronously from given url.
+     *
+     *@memberof Xhr
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@returns {Promise}
+    */
+    get(url, options) {
+        return fetch(url, options, 'GET');
+    },
+
+    /**
+     * post data asynchronously to the given url.
+     *
+     *@memberof Xhr
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@returns {Promise}
+    */
+    post(url, options) {
+        return fetch(url, options, 'POST');
+    },
+
+    /**
+     * put data asynchronously on the given url.
+     *
+     *@memberof Xhr
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@returns {Promise}
+    */
+    put(url, options) {
+        return fetch(url, options, 'PUT');
+    },
+
+    /**
+     * delete data asynchronously on the given url.
+     *
+     *@memberof Xhr
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@returns {Promise}
+    */
+    delete(url, options) {
+        return fetch(url, options, 'DELETE');
+    },
+
+    /**
+     * retrieve a resource meta headers from the given url.
+     *
+     *@memberof Xhr
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@returns {Promise}
+    */
+    head(url, options) {
+        return fetch(url, options, 'HEAD');
+    },
+
+    /**
+     * retrieve resource permitted http communications method verbs from the given url.
+     *
+     *@memberof Xhr
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+     *@returns {Promise}
+    */
+    options(url, options) {
+        return fetch(url, options, 'OPTIONS');
+    },
 };

--- a/src/modules/Xhr/Request.js
+++ b/src/modules/Xhr/Request.js
@@ -101,7 +101,9 @@ function send() {
         this.transport.onprogress = Util.generateCallback(processProgressEvent, this);
 
     this.transport.open(this.method, url, true);
+
     this.transport.responseType = this.responseType;
+    this.transport.withCredentials = this.withCredentials;
 
     this.transport.onload = Util.generateCallback(onLoad, this);
     this.transport.onabort = Util.generateCallback(onAbort, this);
@@ -123,7 +125,20 @@ export default class {
     /**
      * creates a request object
      *@param {string} url - the resource url
-     *@param {Object} [options] - optional request configuration object
+     *@param {Object} options - optional request configuration object
+     *@param {string} [options.method] - http method verb to use
+     *@param {Object|FormData} [options.data] - an object literal or form data containing
+     * request data to send
+     *@param {Object} [options.headers] - an object of http headers to send
+     *@param {string} [options.responseType] - string denoting expected response mime type
+     *@param {string} [options.contentType] - string denoting request content type
+     *@param {boolean} [options.withCredentials] - boolean value indicating if credentials are
+     * are allowed for cross origin requests
+     *@param {string} [options.cache] - request cache directive, default, no-cache or reload
+     *@param {number} [options.timeout] - time in milliseconds to abort request
+     *@param {number} [options.priority] - request priority level. priority is higher in descending order
+     *@param {Function} [options.progress] - request onprogress event callback handler
+     *@param {string} [overrideMethod] - http method verb to use, overrides options method value
     */
     constructor(url, options, resolve, reject, transport) {
         this.method = typeof options.method === 'string'? options.method.toUpperCase() : 'GET';
@@ -145,6 +160,7 @@ export default class {
 
         //resolve request content type
         this.responseType = typeof options.responseType === 'string'? options.responseType : '';
+        this.withCredentials = options.withCredentials? true : false;
         this.contentType = '';
 
         if (this.method === 'POST' || this.method === 'PUT') {

--- a/src/modules/Xhr/Request.js
+++ b/src/modules/Xhr/Request.js
@@ -1,0 +1,181 @@
+import Util from '../Util.js';
+import { host } from '../Globals.js';
+
+/**
+ * processes progress event
+ *@param {Event} e - the progress event object
+*/
+function processProgressEvent(e) {
+    /* istanbul ignore else */
+    if (e.lengthComputable)
+        Util.runSafeWithDefaultArg(this.progress, [e.loaded, e.total]);
+}
+
+/**
+ * processes timeout events
+*/
+function processTimeoutEvent() {
+    this.timedOut = true;
+}
+
+/**
+ * sets request headers
+*/
+function setRequestHeaders() {
+    for (let [name, value] of Object.entries(this.headers))
+        this.transport.setRequestHeader(name, value.toString());
+
+    return this;
+}
+
+/**
+ * sends the request
+*/
+function send() {
+
+    let url = this.url,
+        data  = null,
+        queries = '';
+
+    //resolve data and query
+    if (this.method === 'POST' || this.method === 'PUT') {
+        switch(this.contentType) {
+            case 'application/json':
+            case 'text/json':
+            case 'json':
+                this.contentType = 'application/json';
+                data = JSON.stringify(this.data);
+                break;
+
+            case 'application/x-www-form-urlencoded':
+                data = Util.encodeComponents(this.data);
+                break;
+
+            default:
+                data = this.data;
+        }
+        if (this.contentType)
+            this.headers['Content-Type'] = this.contentType;
+    }
+    else {
+        queries = Util.encodeComponents(this.data);
+        if (queries)
+            url = url + (url.indexOf('?') > -1? '&' : '?') + queries;
+    }
+
+    //resolve cache control
+    switch(this.cache.toLowerCase()) {
+        case 'no-store':
+            this.headers['Cache-Control'] = 'no-store';
+            break;
+        case 'no-cache':
+        case 'reload':
+            this.headers['Cache-Control'] = 'no-cache';
+            this.headers.Pragma = 'no-cache';
+            break;
+        case 'force-cache':
+            this.headers['Cache-Control'] = 'max-stale';
+            break;
+        case 'only-if-cached':
+            this.headers['Cache-Control'] = 'only-if-cached';
+            break;
+    }
+
+    if (this.progress)
+        this.transport.onprogress = Util.generateCallback(processProgressEvent, this);
+
+    this.transport.open(this.method, url, true);
+    this.transport.responseType = this.responseType;
+
+    if (this.timeout) {
+        this.transport.timeout = this.timeout;
+        this.transport.ontimeout = Util.generateCallback(processTimeoutEvent, this);
+    }
+    setRequestHeaders.call(this);
+
+    this.transport.send(data);
+    this.timedOut = false;
+}
+
+export default class {
+
+    /**
+     * creates a request object
+     *@param {string} url - the resource url
+     *@param {Object} [options] - optional request configuration object
+    */
+    constructor(url, options, resolve, reject, transport) {
+
+        options = Util.isPlainObject(options)? options : {};
+        this.method = typeof options.method === 'string'? options.method.toUpperCase() : 'GET';
+
+        if (typeof options.overrideMethod === 'string')
+            this.method = options.overrideMethod.toUpperCase();
+
+        this.url = url.toString();
+
+        this.cache = typeof options.cache === 'string'? options.cache : 'default';
+        this.headers = Util.mergeObjects(options.globalHeaders, options.headers);
+        this.data = Util.isObject(options.data)? options.data : {};
+
+        this.priority = Util.isNumber(options.priority)? options.priority : 5;
+        this.progress = Util.isCallable(options.progress)? options.progress : null;
+
+        this.resolve = resolve;
+        this.reject = reject;
+
+        //resolve request content type
+        this.responseType = typeof options.responseType === 'string'? options.responseType : '';
+        this.contentType = '';
+
+        if (this.method === 'POST' || this.method === 'PUT') {
+            if (typeof options.contentType === 'string')
+                this.contentType = options.contentType;
+            else if (!(this.data instanceof host.FormData))
+                this.contentType = 'application/x-www-form-urlencoded';
+        }
+
+        //resolve request timeout
+        this.timeout = null;
+
+        if (Util.isNumber(options.timeout))
+            this.timeout = options.timeout;
+
+        else if (this.method !== 'POST' && this.method !== 'PUT' && options.timeout !== null && options.timeoutAfter)
+            this.timeout = options.timeoutAfter;
+
+        this.transport = transport;
+    }
+
+    /**
+     * return object identity
+    */
+    get [Symbol.toStringTag]() {
+        return 'Request';
+    }
+
+    /**
+     * sends the request
+    */
+    send() {
+        send.call(this);
+    }
+
+    /**
+     * returns the request state
+     *@type {string}
+    */
+    get state() {
+        if (this.timedOut)
+            return 'complete';
+
+        let readyState = this.transport.readyState.toString();
+        switch(readyState) {
+            case '4':
+            case 'complete':
+                return 'complete';
+            default:
+                return readyState;
+        }
+    }
+}

--- a/src/modules/Xhr/Response.js
+++ b/src/modules/Xhr/Response.js
@@ -45,4 +45,38 @@ export default class {
     get [Symbol.toStringTag]() {
         return 'Response';
     }
+
+    /**
+     * boolean indicating if request status is within the 200 range
+     *@memberof Response#
+     *@type {boolean}
+    */
+    get ok() {
+        if (this.status === 304)
+            return true;
+
+        else if (this.status >= 200 && this.status < 300)
+            return true;
+
+        else
+            return false;
+    }
+
+    /**
+     * response status code
+     *@memberof Response#
+     *@type {number}
+    */
+    get statusCode() {
+        return this.status;
+    }
+
+    /**
+     * response status message
+     *@memberof Response#
+     *@type {string}
+    */
+    get statusMessage() {
+        return this.transport.statusText;
+    }
 }

--- a/src/modules/Xhr/Response.js
+++ b/src/modules/Xhr/Response.js
@@ -112,4 +112,49 @@ export default class {
             return accumulator;
         }, {});
     }
+
+    /**
+     * returns response as json object.
+     *@memberof Response#
+     *@returns {JSON}
+    */
+    json() {
+        return this._json;
+    }
+
+    /**
+     * returns response as blob
+     *@memberof Response#
+     *@returns {Blob}
+    */
+    blob() {
+        return this.transport.response;
+    }
+
+    /**
+     * returns response as array buffer
+     *@memberof Response#
+     *@returns {ArrayBuffer}
+    */
+    arrayBuffer() {
+        return this.transport.response;
+    }
+
+    /**
+     * returns response parsed xml or html document
+     *@memberof Response#
+     *@returns {Document}
+    */
+    document() {
+        return this.transport.response;
+    }
+
+    /**
+     * returns response text
+     *@memberof Response#
+     *@returns {string}
+    */
+    text() {
+        return this.transport.responseText;
+    }
 }

--- a/src/modules/Xhr/Response.js
+++ b/src/modules/Xhr/Response.js
@@ -1,0 +1,48 @@
+import Util from '../Util.js';
+
+/**
+ * parses json content
+ *@param {XMLHttpRequest|ActiveXObject} transport - the request transport object
+ *@returns {Object}
+*/
+function parseJSON(transport) {
+    if (Util.isPlainObject(transport.response))
+        return transport.response;
+
+    let json = null;
+    try {
+        json = JSON.parse(transport.responseText);
+    }
+    catch(ex) {
+        json = {};
+    }
+    return json;
+}
+
+export default class {
+    /**
+     * creates a response object
+     *@param {Request} request - the request
+    */
+    constructor(request) {
+        this.transport = request.transport;
+        this.status = Number.parseInt(request.transport.status);
+        this.headers = null;
+
+        let contentType = (this.getHeader('Content-Type') || '').toLowerCase();
+
+        this._json = null;
+
+        if (request.responseType === 'json' || /(text|application)\/json/.test(contentType))
+            this._json = parseJSON(request.transport);
+
+    }
+
+    /**
+     *@private
+     *@memberof Response#
+    */
+    get [Symbol.toStringTag]() {
+        return 'Response';
+    }
+}

--- a/src/modules/Xhr/Response.js
+++ b/src/modules/Xhr/Response.js
@@ -79,4 +79,37 @@ export default class {
     get statusMessage() {
         return this.transport.statusText;
     }
+
+    /**
+     * returns http response header by the entry name
+     *@memberof Response#
+     *@returns {string} returns string or null if such header was not sent
+    */
+    getHeader(name) {
+        name = name.toString();
+        return this.transport.getResponseHeader(name);
+    }
+
+    /**
+     * returns all response headers as an object
+     *@memberof Response#
+     *@param {boolean} [camelize=true] - boolean value indicating if the header keys should be
+     * turned into camel case to make it easy to the dot (.) operator. like headers.headerName
+     *@returns {Object}
+    */
+    getHeaders(camelize) {
+        if (this.headers === null) {
+            this.headers = {};
+            let headers = this.transport.getAllResponseHeaders().replace(/\n\r?$/, '').split(/\n\r?/);
+            for (let header of headers) {
+                let [name, value] = header.split(':');
+                this.headers[name.toLowerCase()] = value.trim();
+            }
+        }
+        camelize = typeof camelize !== 'undefined' && !camelize? false : true;
+        return !camelize? Object.assign({}, this.headers)  : Object.keys(this.headers).reduce((accumulator, key) => {
+            accumulator[Util.camelCase(key)] = this.headers[key];
+            return accumulator;
+        }, {});
+    }
 }

--- a/src/modules/Xhr/Transport.js
+++ b/src/modules/Xhr/Transport.js
@@ -1,0 +1,91 @@
+import {host, onInstall} from '../Globals.js';
+
+let ieString = '',
+
+    supported = false,
+
+    /**
+     *@private
+     * creates transport through internet explorer active x object construct
+    */
+    /* istanbul ignore next */
+    createActiveXObject = function() {
+        return new host.ActiveXObject(ieString);
+    },
+
+    /**
+     *@private
+     * creates transport through the xml http request construct
+    */
+    creatXMLHttpRequest = function() {
+        return new host.XMLHttpRequest();
+    },
+
+    /**
+     *@private
+     * creates a http request transport object. lazy loads
+     *@returns {XMLHttpRequest}
+    */
+    createTransport = function() {
+        /* istanbul ignore else */
+        if (typeof host.XMLHttpRequest !== 'undefined') {
+            supported = true;
+            createTransport = creatXMLHttpRequest;
+        }
+
+        else if (typeof host.ActiveXObject !== 'undefined') {
+            for (const version of ['MSXML2.XMLHttp.6.0', 'MSXML2.XMLHttp.3.0']) {
+                try {
+                    new host.ActiveXObject(version);
+                    supported = true;
+                    ieString = version;
+                    createTransport = createActiveXObject;
+                    return;
+                }
+                catch(ex) {
+                    //
+                }
+            }
+        }
+
+        else {
+            createTransport = () => {
+                throw new Error('XMLHttpRequest is not supported');
+            };
+        }
+        createActiveXObject = creatXMLHttpRequest = null;
+        return createTransport();
+    };
+
+onInstall(createTransport);
+
+export default {
+
+    /**
+     * boolean value indicating if xhr transport can be created
+     *@type {boolean}
+    */
+    get supported() {
+        return supported;
+    },
+
+    /**
+     * string value that contains the MSXML version string used in creating
+     * the activeXObject, assuming transport was created using this medium
+     *
+     *@type {boolean}
+    */
+    get ieString() {
+        return ieString;
+    },
+
+    /**
+     * creates and returns an xml http request
+     *
+     *@returns {XMLHttpRequest|ActiveXObject}
+     *@throws {Error} throws error if not supported
+    */
+    create() {
+        return createTransport();
+    }
+};

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Browser Tests - ForensicJS</title>
+        <link href="https://unpkg.com/mocha@4.0.1/mocha.css" rel="stylesheet" />
+        <script src="https://unpkg.com/mocha@4.0.1/mocha.js"></script>
+        <script src="https://unpkg.com/chai@4.1.2/chai.js"></script>
+    </head>
+    <body>
+        <div id="mocha"></div>
+        <script type="module">
+            window.expect = chai.expect;
+            mocha.setup('bdd');
+            window.getInstance = function(className, ...parameters) {
+                return new className(...parameters);
+            };
+        </script>
+        <script type="module">
+            import './test/modules/Globals.spec.js';
+            import './test/modules/Util.spec.js';
+            import './test/modules/Queue.spec.js';
+            import './test/modules/Xhr/Transport.spec.js';
+            import './test/modules/Xhr/Request.spec.js';
+            import './test/modules/Xhr/Response.spec.js';
+            import './test/modules/Xhr.spec.js';
+
+            mocha.checkLeaks();
+            mocha.run();
+        </script>
+    </body>
+</html>

--- a/test/modules/Xhr.spec.js
+++ b/test/modules/Xhr.spec.js
@@ -1,0 +1,213 @@
+import Xhr from '../../src/modules/Xhr.js';
+
+describe('Xhr', function() {
+
+    //start up server in node.js environment before any test begins
+    before(function() {
+        if (typeof server !== 'undefined') {
+            server.listen();
+        }
+    });
+
+    //close up server in node.js environment after running tests
+    after(function() {
+        if (typeof server !== 'undefined') {
+            server.close();
+        }
+    });
+
+    describe('.install(hostParam, rootParam)', function() {
+        it('should call the global install method with the given parameter', function() {
+            expect(Xhr.install(window, document)).to.be.false;
+        });
+    });
+
+    describe('.uninstall()', function() {
+        it('should call the global uninstall method', function() {
+            expect(Xhr.uninstall()).to.be.true;
+            expect(Xhr.install(window, document)).to.be.true;
+        });
+    });
+
+    describe('.fetch(url, options?)', function() {
+
+        it('should send request to the resource at the given url and return a promise', function() {
+            expect(Xhr.fetch('/')).to.be.a('promise');
+        });
+
+        it('should pass in a reponse object to the then callback', function() {
+            return Xhr.fetch('/').then(response => {
+                expect(response).to.be.a('Response');
+            });
+        });
+
+        it('should accept an optional request options object as second parameter as covered in the Request module', function() {
+            return Xhr.fetch('/', {}).then(response => {
+                expect(response).to.be.a('Response');
+            });
+        });
+
+        it(`should reject the response if response status code is not within the 200 range and it
+        is not a 304 status code`, function() {
+            return Xhr.fetch('unexisting-file.html').catch(response => {
+                expect(response.statusCode).equals(404);
+            });
+        });
+    });
+
+    describe('.get(url, options?)', function() {
+        it('should send request to the resource at the given url using the GET method verb', function() {
+            return Xhr.get('report/request-method').then((response) => {
+                expect(response.getHeaders().xRequestMethod).to.equals('GET');
+            });
+        });
+    });
+
+    describe('.post(url, options?)', function() {
+        it('should send request to the resource at the given url using the POST method verb', function() {
+            return Xhr.post('report/request-method').then((response) => {
+                expect(response.getHeaders().xRequestMethod).to.equals('POST');
+            });
+        });
+    });
+
+    describe('.put(url, options?)', function() {
+        it('should send request to the resource at the given url using the PUT method verb', function() {
+            return Xhr.put('report/request-method').then((response) => {
+                expect(response.getHeaders().xRequestMethod).to.equals('PUT');
+            });
+        });
+    });
+
+    describe('.delete(url, options?)', function() {
+        it('should send request to the resource at the given url using the DELETE method verb', function() {
+            return Xhr.delete('report/request-method').then((response) => {
+                expect(response.getHeaders().xRequestMethod).to.equals('DELETE');
+            });
+        });
+    });
+
+    describe('.options(url, options?)', function() {
+        it('should send request to the resource at the given url using the OPTIONS method verb', function() {
+            return Xhr.options('report/request-method').then((response) => {
+                expect(response.getHeaders().xRequestMethod).to.equals('OPTIONS');
+            });
+        });
+    });
+
+    describe('.head(url, options?)', function() {
+        it('should send request to the resource at the given url using the HEAD method verb', function() {
+            return Xhr.head('report/request-method').then((response) => {
+                expect(response.getHeaders().xRequestMethod).to.equals('HEAD');
+            });
+        });
+    });
+
+    describe('.timeoutAfter(ms?)', function() {
+        it(`should return the default request timeout value in milliseconds if no milliseconds
+        time argument is passed in. The default value is 15 seconds`, function() {
+            expect(Xhr.timeoutAfter()).to.equals(15000);
+        });
+
+        it(`should set the default request timeout value to the passed in milliseconds
+        time argument`, function() {
+            Xhr.timeoutAfter(10000);
+            expect(Xhr.timeoutAfter()).to.equals(10000);
+
+            //set it back
+            Xhr.timeoutAfter(15000);
+        });
+    });
+
+    describe('.pollAfter(ms?)', function() {
+        it(`should return the default time in milliseconds that the module waits before polling
+        for the next request if no milliseconds time argument is supplied. Default value is 250
+        milliseconds`, function() {
+            expect(Xhr.pollAfter()).to.equals(250);
+        });
+
+        it(`should set the default time in milliseconds that the module waits before polling
+        for the next request to the given milliseconds time argument.`, function() {
+            Xhr.pollAfter(500);
+            expect(Xhr.pollAfter()).to.equals(500);
+
+            //set it back
+            Xhr.pollAfter(250);
+        });
+    });
+
+    describe('.promoteAfter(ms?)', function() {
+        it(`should return the default time in milliseconds that a pending request must stay
+        before its priority is promoted one step higher if no milliseconds time argument is
+        supplied. Default value is 3000 milliseconds`, function() {
+            expect(Xhr.promoteAfter()).to.equals(3000);
+        });
+
+        it(`should set the default time in milliseconds that a pending request must have stay
+        before its priority is promoted one step higher to the given milliseconds time argument.`, function() {
+            //set the value to something lesser than poll time
+            Xhr.promoteAfter(150);
+            expect(Xhr.promoteAfter()).to.equals(150);
+
+            return Xhr.fetch('/').then(() => {
+                //do nothing. just want to cover request age decrementing
+                Xhr.promoteAfter(3000);
+            });
+        });
+    });
+
+    describe('.supported', function() {
+        it('it should hold a boolean value that indicates if XMLHttpRequest is supported', function() {
+            expect(Xhr.supported).to.be.true;
+        });
+    });
+
+    describe('.ieString', function() {
+        it(`it should hold the MSXML version string used in creating the request transport if
+        the environment is running in a trident engine that implements XMLHttpRequest through
+        ActiveXObject`, function() {
+            expect(Xhr.ieString).to.be.a('string');
+        });
+    });
+
+    describe('.addHeader(name, value)', function() {
+        it(`should add a global header whose name is the given name that will get sent for all
+        http request made using the module.`, function() {
+            Xhr.addHeader('X-Requested-With', 'XMLHttpRequest');
+            return Xhr.fetch('report-header/x-requested-with').then((response) => {
+                expect(response.text()).to.equals('XMLHttpRequest');
+            });
+        });
+    });
+
+    describe('.addHeaders(entries)', function() {
+        it(`should add multiple global headers using the entries' key:value pairs
+        that will get sent for all http request made using the module.`, function() {
+            Xhr.addHeaders({
+                'X-CSRF-TOKEN': 'random_token'
+            });
+            return Xhr.fetch('report-header/x-csrf-token').then((response) => {
+                expect(response.text()).to.equals('random_token');
+            });
+        });
+    });
+
+    describe('.removeHeader(headerName)', function() {
+        it(`should remove the given header from the global headers list when called`, function() {
+            Xhr.removeHeader('X-CSRF-TOKEN');
+            return Xhr.fetch('report-header/x-csrf-token').then((response) => {
+                expect(response.text()).to.equals('undefined');
+            });
+        });
+    });
+
+    describe('.removeHeaders(...headerNames)', function() {
+        it(`should remove the comma separated list of headers from the global headers list when
+        called`, function() {
+            Xhr.removeHeaders('X-Requested-With');
+            return Xhr.fetch('report-header/x-request-with').then((response) => {
+                expect(response.text()).to.equals('undefined');
+            });
+        });
+    });
+});

--- a/test/modules/Xhr/Request.spec.js
+++ b/test/modules/Xhr/Request.spec.js
@@ -80,6 +80,12 @@ describe('Request', function() {
             expect(request.progress).to.equals(progress);
         });
 
+        it(`should set the request withCredentials to the given options.withCredentials boolean
+         parameter if given. default value is false`, function() {
+            let request = new Request('/', {withCredentials: true}, () => {}, () => {}, transport);
+            expect(request.withCredentials).to.equals(true);
+        });
+
         it(`should set the request contentType to the given options.contentType parameter when
         the request method is post or put. default value for post or put requests is
         'application/x-www-form-urlencoded'`, function() {

--- a/test/modules/Xhr/Request.spec.js
+++ b/test/modules/Xhr/Request.spec.js
@@ -318,13 +318,14 @@ describe('Request', function() {
         it(`should abort the request when called`, function() {
             let request = new Request('/', {}, () => {}, () => {}, transport);
 
-            setTimeout(function() {
-                request.abort();
-            }, 1);
-            return request.send().then((request) => {
+            let promise = request.send().then((request) => {
                 expect(request.aborted).to.equals(true);
                 expect(request.state).to.equals('complete');
             });
+
+            request.abort();
+
+            return promise;
         });
     });
 

--- a/test/modules/Xhr/Request.spec.js
+++ b/test/modules/Xhr/Request.spec.js
@@ -1,0 +1,394 @@
+import Request from '../../../src/modules/Xhr/Request.js';
+import Transport from '../../../src/modules/Xhr/Transport.js';
+
+describe('Request', function() {
+    let transport = null;
+
+    //start up server in node.js environment before any test begins
+    before(function() {
+        if (typeof server !== 'undefined') {
+            server.listen();
+        }
+    });
+
+    //close up server in node.js environment after running tests
+    after(function() {
+        if (typeof server !== 'undefined') {
+            server.close();
+        }
+    });
+
+    beforeEach(function() {
+        transport = Transport.create();
+    });
+
+    describe('#constructor(url, options, resolve, reject, transport)', function() {
+        it(`should create a Request object if given a request url, options object, resolve and
+        reject promises methods, and a transport object`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request).to.be.a('Request');
+        });
+
+        it(`should create a request object with a default options if options argument is not a
+        plain object`, function() {
+            let request = new Request('/', null, () => {}, () => {}, transport);
+            expect(request.method).to.equals('GET');
+        });
+
+        it(`should set the request method to the given options.method parameter. default value
+        is GET`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request.method).to.equals('GET');
+
+            request = new Request('/', {method: 'post'}, () => {}, () => {}, transport);
+            expect(request.method).to.equals('POST');
+        });
+
+        it(`should override the request method with the options.overrideMethod parameter if given`, function() {
+            let request = new Request('/', {method: 'GET', overrideMethod: 'POST'}, () => {}, () => {}, transport);
+            expect(request.method).to.equals('POST');
+        });
+
+        it(`should set the request cache to the given options.cache parameter. default value
+        is default`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request.cache).to.equals('default');
+
+            request = new Request('/', {cache: 'no-store'}, () => {}, () => {}, transport);
+            expect(request.cache).to.equals('no-store');
+        });
+
+        it(`should set the request data to the given options.data parameter. default value
+        is empty plain object {}`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request.data).to.deep.equals({});
+
+            request = new Request('/', {data: {name: 'something'}}, () => {}, () => {}, transport);
+            expect(request.data).to.deep.equals({name: 'something'});
+        });
+
+        it(`should set the request priority to the given options.priority parameter. default value
+        is 5`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request.priority).to.equals(5);
+
+            request = new Request('/', {priority: 3}, () => {}, () => {}, transport);
+            expect(request.priority).to.equals(3);
+        });
+
+        it(`should set the request progress callback to the given options.progress parameter. default value
+        is null`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request.progress).to.equals(null);
+
+            let progress = () => {};
+            request = new Request('/', {progress: progress}, () => {}, () => {}, transport);
+            expect(request.progress).to.equals(progress);
+        });
+
+        it(`should set the request contentType to the given options.contentType parameter when
+        the request method is post or put. default value for post or put requests is
+        'application/x-www-form-urlencoded'`, function() {
+            let request = new Request('/', {method: 'post'}, () => {}, () => {}, transport);
+            expect(request.contentType).to.equals('application/x-www-form-urlencoded');
+
+            request = new Request('/', {method: 'put', contentType: 'application/json'}, () => {}, () => {}, transport);
+            expect(request.contentType).to.equals('application/json');
+        });
+
+        it(`should set the request contentType to 'application/x-www-form-urlencoded' if
+        request method is either post or put`, function() {
+            let request = new Request('/', {method: 'POST'}, () => {}, () => {}, transport);
+            expect(request.contentType).to.equals('application/x-www-form-urlencoded');
+
+            request = new Request('/', {method: 'PUT'}, () => {}, () => {}, transport);
+            expect(request.contentType).to.equals('application/x-www-form-urlencoded');
+        });
+
+        it(`should set the request timeout to the given options.timeout parameter. default value
+        is null`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request.timeout).to.equals(null);
+
+            request = new Request('/', {timeout: 5000}, () => {}, () => {}, transport);
+            expect(request.timeout).to.equals(5000);
+        });
+
+        it(`should set the request timeout to the given default options.timeoutAfter parameter
+        if request method is neither post nor put and user did not specify timeout`, function() {
+            let request = new Request('/', {timeoutAfter: 15000}, () => {}, () => {}, transport);
+            expect(request.timeout).to.equals(15000);
+        });
+
+        it(`should set the request timeout to null if options.timeout is null`, function() {
+            let request = new Request('/', {timeoutAfter: 15000, timeout: null}, () => {}, () => {}, transport);
+            expect(request.timeout).to.equals(null);
+        });
+
+        it(`should set the request responseType property to the given options.responseType
+        parameter`, function() {
+            let request = new Request('/', {responseType: 'json'}, () => {}, () => {}, transport);
+            expect(request.responseType).to.equals('json');
+        });
+    });
+
+    describe('#send()', function() {
+
+        it(`should send the request when called`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'Hello World')
+                    done();
+                else
+                    done(new Error('request was not sent'));
+            };
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request, terminating the request if response time exceeds timeout
+        value`, function(done) {
+            let request = new Request('/prolong-response', {timeout: 1000}, () => {}, () => {}, transport);
+            request.send();
+            setTimeout(function() {
+                if (request.timedOut && request.state === 'complete')
+                    done();
+                else
+                    done(new Error('Failed to timeout request'));
+            }, 1200);
+        });
+
+        it(`should send the request, watching for progress event if an options.progress callback
+        method is specified`, function(done) {
+            let callCount = 0;
+            let request = new Request('/', {progress: () => {
+                if (callCount === 0) {
+                    callCount += 1;
+                    done();
+                }
+            }}, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should ignore the contentType options and send the request when called,
+        sending data content as query parameters if method is neither post nor put`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === '{"name":"Harrison","age":"22"}')
+                    done();
+                else
+                    done(new Error(transport.responseText + ' does not match sent query'));
+            };
+            let request = new Request('/report-query', {
+                method: 'GET',
+                data: {
+                    name: 'Harrison',
+                    age: 22
+                }
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should append the data to the existing query in the url if there is already an
+        existing query in the url`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === '{"name":"Harrison","age":"22"}')
+                    done();
+                else
+                    done(new Error(transport.responseText + ' does not match sent query'));
+            };
+            let request = new Request('/report-query?name=Harrison', {
+                method: 'GET',
+                data: {
+                    age: 22
+                }
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending form-urlencoded content to the server if the
+        request method is post or put and request data is not a form-data and contentType header
+        is not set or is set as 'application/x-www-form-urlencoded'`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'application/x-www-form-urlencoded')
+                    done();
+                else
+                    done(new Error('request content-type header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/content-type', {
+                method: 'post',
+                data: {
+                    name: 'Harrison',
+                    age: 22
+                }
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending json content to the server if the
+        request method is post or put and contentType header is set as 'json'`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'application/json')
+                    done();
+                else
+                    done(new Error('request content-type header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/content-type', {
+                method: 'post',
+                contentType: 'json',
+                data: {
+                    name: 'Harrison',
+                    age: 22
+                }
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending json content to the server if the
+        request method is post or put and contentType header is set as 'application/json'`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'application/json')
+                    done();
+                else
+                    done(new Error('request content-type header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/content-type', {
+                method: 'post',
+                contentType: 'application/json',
+                data: {
+                    name: 'Harrison',
+                    age: 22
+                }
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending json content to the server if the
+        request method is post or put and contentType header is set as 'text/json'`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'application/json')
+                    done();
+                else
+                    done(new Error('request content-type header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/content-type', {
+                method: 'post',
+                contentType: 'text/json',
+                data: {
+                    name: 'Harrison',
+                    age: 22
+                }
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending multipart/form-data with boundary token
+         to the server if request method is post or put and request data is a form data`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText.indexOf('multipart/form-data') > -1)
+                    done();
+                else
+                    done(new Error(transport.responseText + ' content-type header sent to server is invalid'));
+            };
+            let formData = new window.FormData();
+            formData.append('name', 'Harrison');
+
+            let request = new Request('/report-header/content-type', {
+                method: 'post',
+                data: formData
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending the appropriate cache-control header
+        for the given 'no-store' options.cache value`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'no-store')
+                    done();
+                else
+                    done(new Error('request cache-control header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/cache-control', {
+                cache: 'no-store'
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending the appropriate cache-control header
+        for the given 'reload' options.cache value`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'no-cache')
+                    done();
+                else
+                    done(new Error('request cache-control header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/cache-control', {
+                cache: 'reload'
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending the appropriate cache-control header
+        for the given 'no-cache' options.cache value`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'no-cache')
+                    done();
+                else
+                    done(new Error('request cache-control header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/cache-control', {
+                cache: 'no-cache'
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending the appropriate cache-control header
+        for the given 'force-cache' options.cache value`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'max-stale')
+                    done();
+                else
+                    done(new Error('request cache-control header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/cache-control', {
+                cache: 'force-cache'
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+
+        it(`should send the request when called, sending the appropriate cache-control header
+        for the given 'only-if-cached' options.cache value`, function(done) {
+            transport.onload = () => {
+                if (transport.responseText === 'only-if-cached')
+                    done();
+                else
+                    done(new Error('request cache-control header sent to server is invalid'));
+            };
+            let request = new Request('/report-header/cache-control', {
+                cache: 'only-if-cached'
+            }, () => {}, () => {}, transport);
+            request.send();
+        });
+    });
+
+    describe('#state', function() {
+
+        it(`should return the request current state`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            expect(request.state).to.equals('0');
+        });
+
+        it(`should be updated as the request gets sent, progressing and finally gets to the
+        complete state`, function(done) {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            request.send();
+
+            let checkState = () => {
+                if (request.state === 'complete')
+                    done();
+                else
+                    setTimeout(checkState, 50);
+            };
+
+            setTimeout(checkState, 50);
+        });
+    });
+});

--- a/test/modules/Xhr/Request.spec.js
+++ b/test/modules/Xhr/Request.spec.js
@@ -313,6 +313,21 @@ describe('Request', function() {
         });
     });
 
+    describe('#abort()', function() {
+
+        it(`should abort the request when called`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+
+            setTimeout(function() {
+                request.abort();
+            }, 1);
+            return request.send().then((request) => {
+                expect(request.aborted).to.equals(true);
+                expect(request.state).to.equals('complete');
+            });
+        });
+    });
+
     describe('#state', function() {
 
         it(`should return the request current state`, function() {

--- a/test/modules/Xhr/Response.spec.js
+++ b/test/modules/Xhr/Response.spec.js
@@ -1,0 +1,216 @@
+import Transport from '../../../src/modules/Xhr/Transport.js';
+import Request from '../../../src/modules/Xhr/Request.js';
+import Response from '../../../src/modules/Xhr/Response.js';
+
+describe('Request', function() {
+    let transport = null;
+
+    //start up server in node.js environment before any test begins
+    before(function() {
+        if (typeof server !== 'undefined') {
+            server.listen();
+        }
+    });
+
+    //close up server in node.js environment after running tests
+    after(function() {
+        if (typeof server !== 'undefined') {
+            server.close();
+        }
+    });
+
+    beforeEach(function() {
+        transport = Transport.create();
+    });
+
+    describe('#constructor(request)', function() {
+        it('should create a response object given the request object', function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                expect(new Response(request)).to.be.a('Response');
+            });
+        });
+    });
+
+    describe('#statusCode', function() {
+        it('should reflect the response status code as sent by the server as an integer', function() {
+            let request = new Request('user/create', {method: 'POST'}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.statusCode).to.equals(201);
+            });
+        });
+    });
+
+    describe('#statusMessage', function() {
+        it('should reflect the response status message as sent by the server', function() {
+            let request = new Request('user/create', {method: 'POST'}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.statusMessage).to.equals('User created');
+            });
+        });
+    });
+
+    describe('#getHeader(name)', function() {
+        it(`should return the response header value for the given response header name as
+        returned by the server`, function() {
+            let request = new Request('package.json', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.getHeader('Content-Type')).to.equals('application/json');
+            });
+        });
+
+        it(`should return null if no header of the given name was sent by the server`, function() {
+            let request = new Request('package.json', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.getHeader('Content-Typ')).to.equals(null);
+            });
+        });
+    });
+
+    describe('#getHeaders(camelize?)', function() {
+        it(`should return all response headers sent by the server as an object with all
+        header names turned into camel cases`, function() {
+            let request = new Request('package.json', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+
+                expect(response.getHeaders()).to.be.an('object')
+                    .and.to.have.own.property('contentType')
+                    .but.not.own.property('content-type');
+
+                response.getHeaders();
+            });
+        });
+
+        it(`should return all the headers with the object keys as lowercase but not camelized
+        if the camelize option is set as false. Default value is true`, function() {
+            let request = new Request('package.json', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+
+                expect(response.getHeaders(false)).to.be.an('object')
+                    .and.to.have.own.property('content-type')
+                    .but.not.own.property('contentType');
+            });
+        });
+    });
+
+    describe('#text()', function() {
+        it(`should return the reponse text`, function() {
+            let request = new Request('/', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.text()).to.equals('Hello World');
+            });
+        });
+    });
+
+    describe('#json()', function() {
+        it(`should return the parsed json object for all server response with Content-Type
+        header of either 'application/json' or 'text/json'`, function() {
+            let request = new Request('package.json', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+
+                expect(response.getHeaders(false)['content-type']).to.equals('application/json');
+                expect(response.json().name).to.equals('forensic-js');
+            });
+        });
+
+        it(`should return the parsed json object for all requests whose options.responseType
+        parameter is set as 'json' even when the server fails to send the correct Content-Type
+        header`, function() {
+            let request = new Request('send-incorrect-content-type/json', {responseType: 'json'}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+
+                expect(response.json().message).to.equals('I still parsed it');
+            });
+        });
+
+        it(`should return an empty plain object if json string could not be parsed`, function() {
+            let request = new Request('send-invalid-content/json', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.json()).to.deep.equals({});
+            });
+        });
+
+        it(`should return null if response content-type header is neither 'application/json' nor
+        'text/json' and request's options.responseType parameter is not set as 'json'`, function() {
+            let request = new Request('README.md', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.json()).to.equals(null);
+            });
+        });
+    });
+
+    describe('#arrayBuffer()', function() {
+        it(`should return the parsed response as array buffer for all requests whose options.responseType
+        parameter is set as 'arraybuffer'`, function() {
+            let request = new Request('/', {responseType: 'arraybuffer'}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+
+                expect(response.arrayBuffer()).to.be.an('ArrayBuffer');
+            });
+        });
+    });
+
+    describe('#blob()', function() {
+        it(`should return the parsed response as blob for all requests whose options.responseType
+        parameter is set as 'blob'`, function() {
+            let request = new Request('/', {responseType: 'blob'}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+
+                expect(response.blob()).to.be.a('Blob');
+            });
+        });
+    });
+
+    describe('#document()', function() {
+        it(`should return the parsed response as document for all requests whose options.responseType
+        parameter is set as 'document'`, function() {
+            let request = new Request('/send-content/html', {responseType: 'document'}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.document().nodeType).to.equals(9);
+            });
+        });
+    });
+
+    describe('#ok', function() {
+        it(`should be true if the request response code is within the 200 range'`, function() {
+            let request = new Request('/send-response-code/204', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.statusCode).to.equals(204);
+                expect(response.ok).to.be.true;
+            });
+        });
+
+        it(`should be true if the request response code is 304'`, function() {
+            let request = new Request('/send-response-code/304', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.statusCode).to.equals(304);
+                expect(response.ok).to.be.true;
+            });
+        });
+
+        it(`should be false for all other response code values'`, function() {
+            let request = new Request('/send-response-code/301', {}, () => {}, () => {}, transport);
+            return request.send().then(function (request) {
+                let response = new Response(request);
+                expect(response.statusCode).to.equals(301);
+                expect(response.ok).to.be.false;
+            });
+        });
+    });
+});

--- a/test/modules/Xhr/Transport.spec.js
+++ b/test/modules/Xhr/Transport.spec.js
@@ -1,0 +1,22 @@
+import Transport from '../../../src/modules/Xhr/Transport.js';
+
+describe('Transport', function() {
+    describe('.create()', function() {
+        it(`should create an xhr transport object`, function() {
+            expect(Transport.create()).to.be.an('XMLHttpRequest');
+        });
+    });
+
+    describe('.supported', function() {
+        it(`should return a boolean indicating if transport objects can be created`, function() {
+            expect(Transport.supported).to.be.true;
+        });
+    });
+
+    describe('.ieString', function() {
+        it(`should return a string indicating the MSXML version string used in created the
+        xmlhttprequest activeXobject, assuming it is running in ie`, function() {
+            expect(Transport.ieString).to.be.string;
+        });
+    });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -12,5 +12,6 @@ let dom = new JSDOM('<!doctype html><html><body></body></html>', {
  * set up test global variables including a test server to be used for http requests
 */
 global.expect = require('chai').expect;
+global.server = require('../server/app.js');
 global.window = dom.window;
 global.document = window.document;


### PR DESCRIPTION
The module offers promise based fetch api with the following features.

1. Exposes restful methods for handling all http request method verbs.

2. Ability to set global headers that are sent with every http request

3. Ability to prioritize requests, with polling manager

4. Ability to promote requests, in order to balance request prioritization

5. Supports features exposed by latest web Request, Response, Headers, and Fetch API

Usage sample:

```javascript
Xhr.fetch(url, options).then((response) => {
    console.log(response.text());
});

Xhr.get(url, options).then((response) => {
    console.log(response.text());
});

Xhr.post(url, options).then((response) => {
    console.log(response.text());
});

......
```
