### PR TITLE
Feat: add XPath module, it unifies IE ActiveXObject and DOM implementations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5753,6 +5753,12 @@
         "isexe": "^2.0.0"
       }
     },
+    "wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w=",
+      "dev": true
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "rollup-all": "1.3.0",
     "rollup-plugin-babel": "3.0.7",
     "rollup-plugin-node-resolve": "3.3.0",
-    "rollup-plugin-uglify": "4.0.0"
+    "rollup-plugin-uglify": "4.0.0",
+    "wicked-good-xpath": "1.3.0"
   },
   "czConfig": {
     "path": "node_modules/cz-conventional-changelog"

--- a/src/modules/XML.js
+++ b/src/modules/XML.js
@@ -124,6 +124,7 @@ let xmlStates = {
             createDocument = creatDOMImplementationDocument;
         }
 
+        /* istanbul ignore if */
         if (!xmlStates.supported)
             createDocument = () => {
                 throw new Error('XML Document is not supported');

--- a/src/modules/XML.js
+++ b/src/modules/XML.js
@@ -222,13 +222,16 @@ let xmlStates = {
  * sets up the xml module
 */
 let init = function() {
-    let xml = createDocument();
 
     /* istanbul ignore if */
     if (xmlStates.ieString)
         return;
 
-    let xmlDocumentInterface = null;
+    xmlStates.parser = new host.DOMParser();
+    xmlStates.serializer = new host.XMLSerializer();
+
+    let xml = createDocument(),
+        xmlDocumentInterface = null;
 
     /* istanbul ignore if */
     if (Util.objectIsA(xml, 'XMLDocument'))
@@ -282,9 +285,6 @@ let init = function() {
             return text.call(this);
         }
     });
-
-    xmlStates.parser = new host.DOMParser();
-    xmlStates.serializer = new host.XMLSerializer();
 };
 
 onInstall(init);

--- a/src/modules/XML.js
+++ b/src/modules/XML.js
@@ -123,11 +123,11 @@ let xmlStates = {
             xmlStates.supported = true;
             createDocument = creatDOMImplementationDocument;
         }
-        else {
+
+        if (!xmlStates.supported)
             createDocument = () => {
                 throw new Error('XML Document is not supported');
             };
-        }
 
         creatDOMImplementationDocument = createActiveXObjectDocument = null;
         return createDocument(prolog, documentType);

--- a/src/modules/XPath.js
+++ b/src/modules/XPath.js
@@ -1,0 +1,36 @@
+import { onInstall} from './Globals.js';
+import XML from './XML.js';
+
+let xPathStates = {
+        /**
+         * boolean value indicating if xPath is supported
+        */
+        supported: false,
+
+        /**
+         * tells the kind of xPath implementation used
+        */
+        implementation: 0
+    },
+
+    /**
+     * initialize the module
+    */
+    init = function () {
+        let xml = new XML();
+        /* istanbul ignore if */
+        if (typeof xml.document.selectSingleNode !== 'undefined') {
+            //internet explorer implementation
+            xPathStates.supported = true;
+            xPathStates.implementation = 1;
+        }
+
+        /* istanbul ignore else */
+        if (!xPathStates.supported && typeof xml.document.evaluate !== 'undefined') {
+            //domimplementation
+            xPathStates.supported = true;
+            xPathStates.implementation = 2;
+        }
+    };
+
+onInstall(init);

--- a/src/modules/XPath.js
+++ b/src/modules/XPath.js
@@ -1,4 +1,4 @@
-import { onInstall} from './Globals.js';
+import { onInstall, install, uninstall } from './Globals.js';
 import XML from './XML.js';
 
 let xPathStates = {
@@ -34,3 +34,44 @@ let xPathStates = {
     };
 
 onInstall(init);
+
+export default {
+    /**
+     * calls the Globals install method with the parameters. This is useful when using the
+     * Utils module as a standalone distribution or lib.
+     *
+     *@param {Object} hostParam - the host object, the global this object in a given usage
+     * environment
+     *@param {Object} rootParam - the root object. an example is the document object
+     *@returns {boolean}
+    */
+    install(hostParam, rootParam) {
+        return install(hostParam, rootParam);
+    },
+
+    /**
+     * calls the Globals uninstall method with the parameters. This is useful when using the
+     * Utils module as a standalone distribution or lib.
+     *
+     *@returns {boolean}
+    */
+    uninstall() {
+        return uninstall();
+    },
+
+    /**
+     * indicates if xPath is supported
+     *@type {boolean}
+    */
+    get supported() {
+        return xPathStates.supported;
+    },
+
+    /**
+     * indicates the XPath implementation type that is supported
+     *@type {number}
+    */
+    get implementation() {
+        return xPathStates.implementation;
+    },
+};

--- a/src/modules/XPath.js
+++ b/src/modules/XPath.js
@@ -1,4 +1,5 @@
-import { onInstall, install, uninstall } from './Globals.js';
+import { onInstall, host, install, uninstall } from './Globals.js';
+import Util from './Util.js';
 import XML from './XML.js';
 
 let xPathStates = {
@@ -11,6 +12,61 @@ let xPathStates = {
          * tells the kind of xPath implementation used
         */
         implementation: 0
+    },
+
+    /**
+     * resolves namespace specific to ActiveXObject implementation only and returns the
+     * resolved namespace or empty string
+     *
+     *@param {Object} [namespaces] - the namespace object
+     *@returns {string}
+    */
+    /* istanbul ignore next */
+    resolveActiveXObjectNamespace = function (namespaces) {
+        if (!Util.isPlainObject(namespaces))
+            return '';
+        else
+            return Object.keys(namespaces).map(key => {
+                return `xmlns:${key}="${namespaces[key]}"`;
+            }).join(' ');
+    },
+
+    /**
+     * returns a dom implementation namesapace resolver for the given namespace.
+     *@param {Object} [namespaces] - the namespace object
+     *@returns {Function|null}
+    */
+    resolveDOMImplementationNamespace = function (namespaces) {
+        if (Util.isPlainObject(namespaces))
+            return function(prefix) {
+                /* istanbul ignore else */
+                if (typeof namespaces[prefix] !== 'undefined')
+                    return namespaces[prefix];
+                else
+                    return null;
+            };
+        else
+            return null;
+    },
+
+    /**
+     * validates the selector and node
+     *@param {string} selector - the xPath selector
+     *@param {Document|Element} node - the context node
+     *@returns {Document}
+    */
+    validate = function(selector, node) {
+        if (typeof selector !== 'string')
+            throw new TypeError(selector + ' is not an xPath selector');
+
+        if (!Util.isElementNode(node) && !Util.isDocumentNode(node))
+            throw new TypeError(node + ' is not a valid xPath selection context node');
+
+        /* istanbul ignore if */
+        if (!xPathStates.supported)
+            throw new Error('XPath is not supported');
+
+        return Util.isElementNode(node)? node.ownerDocument : node;
     },
 
     /**
@@ -73,5 +129,28 @@ export default {
     */
     get implementation() {
         return xPathStates.implementation;
+    },
+
+    /**
+     * selects the first matching node or null if there is no match
+     *@param {string} selector - the xPath selector
+     *@param {Document|Element} node - the context node
+     *@param {Object} [namespaces] - the namespaces object
+     *@returns {Node|null}
+    */
+    selectNode(selector, node, namespaces) {
+        let reference = validate(selector, node);
+        /* istanbul ignore if */
+        if (xPathStates.implementation == 1) {
+            reference.setProperty('SelectionNamespaces', resolveActiveXObjectNamespace(namespaces));
+            return node.selectSingleNode(selector);
+        }
+        else {
+            let xPathResult = reference.evaluate(
+                selector, node, resolveDOMImplementationNamespace(namespaces),
+                host.XPathResult.FIRST_ORDERED_NODE_TYPE, null
+            );
+            return xPathResult.singleNodeValue;
+        }
     },
 };

--- a/src/modules/XPath.js
+++ b/src/modules/XPath.js
@@ -212,4 +212,24 @@ export default {
     selectNodes(selector, node, namespaces) {
         return selectNodes(selector, node, ...validate(selector, node, namespaces));
     },
+
+    /**
+     * selects and returns the first matching node from alternate xPath expression or null if
+     * there is no match found. alternate xPath expressions are separated using double pipe (||)
+     *@param {string} selector - the xPath selector
+     *@param {Document|Element} node - the context node
+     *@param {Object} [namespaces] - the namespaces object
+     *@returns {Node|null}
+    */
+    selectAltNode(selector, node, namespaces) {
+        let [namespaceResolver, reference] = validate(selector, node, namespaces);
+
+        for(selector of selector.split(/\s*\|\|\s*/)) {
+            let result = selectNode(selector, node, namespaceResolver, reference);
+            if (result !== null)
+                return result;
+        }
+
+        return null;
+    }
 };

--- a/src/modules/XPath.js
+++ b/src/modules/XPath.js
@@ -153,4 +153,35 @@ export default {
             return xPathResult.singleNodeValue;
         }
     },
+
+    /**
+     * returns an array of all matching node items
+     *@param {string} selector - the xPath selector
+     *@param {Document|Element} node - the context node
+     *@param {Object} [namespaces] - the namespaces object
+     *@returns {Node[]}
+    */
+    selectNodes(selector, node, namespaces) {
+        let reference = validate(selector, node);
+        /* istanbul ignore if */
+        if (xPathStates.implementation == 1) {
+            reference.setProperty('SelectionNamespaces', resolveActiveXObjectNamespace(namespaces));
+            return [...node.selectNodes(selector)];
+        }
+        else {
+            let xPathResult = reference.evaluate(
+                    selector, node, resolveDOMImplementationNamespace(namespaces),
+                    host.XPathResult.ORDERED_NODE_ITERATOR_TYPE, null
+                ),
+                result = [];
+
+            let current = xPathResult.iterateNext();
+            while (current) {
+                result.push(current);
+                current = xPathResult.iterateNext();
+            }
+
+            return result;
+        }
+    }
 };

--- a/src/modules/XPath.js
+++ b/src/modules/XPath.js
@@ -214,8 +214,9 @@ export default {
     },
 
     /**
-     * selects and returns the first matching node from alternate xPath expression or null if
-     * there is no match found. alternate xPath expressions are separated using double pipe (||)
+     * returns the first node that matches one of the alternate xPath selectors
+     * separated using double pipe (||), under the given node context or null if no
+     * result is found
      *@param {string} selector - the xPath selector
      *@param {Document|Element} node - the context node
      *@param {Object} [namespaces] - the namespaces object
@@ -231,5 +232,26 @@ export default {
         }
 
         return null;
+    },
+
+    /**
+     * returns array of node that matches one of the alternate xPath selectors
+     * separated using double pipe (||), under the given node context or empty array if no
+     * result is found
+     *@param {string} selector - the xPath selector
+     *@param {Document|Element} node - the context node
+     *@param {Object} [namespaces] - the namespaces object
+     *@returns {Node[]}
+    */
+    selectAltNodes(selector, node, namespaces) {
+        let [namespaceResolver, reference] = validate(selector, node, namespaces);
+
+        for(selector of selector.split(/\s*\|\|\s*/)) {
+            let result = selectNodes(selector, node, namespaceResolver, reference);
+            if (result.length > 0)
+                return result;
+        }
+
+        return [];
     }
 };

--- a/test/index.html
+++ b/test/index.html
@@ -48,6 +48,7 @@
             import './test/modules/Event.spec.js';
 
             import './test/modules/XML.spec.js';
+            import './test/modules/XPath.spec.js';
 
             mocha.checkLeaks();
             mocha.run();

--- a/test/modules/Globals.spec.js
+++ b/test/modules/Globals.spec.js
@@ -1,9 +1,6 @@
 import * as Globals from '../../src/modules/Globals.js';
 
 describe('Globals', function() {
-    after(function() {
-        Globals.install(window, document);
-    });
 
     describe('.installed()', function() {
         it('should return true if library globals has been installed', function() {
@@ -41,7 +38,7 @@ describe('Globals', function() {
     });
 
     describe('.uninstall()', function() {
-        beforeEach(function() {
+        afterEach(function() {
             Globals.install(window, document);
         });
 
@@ -65,50 +62,35 @@ describe('Globals', function() {
     });
 
     describe('.host', function() {
-        beforeEach(function() {
-            Globals.uninstall();
-        });
 
-        it('should be null until library globals are installed', function() {
+        it('should be null when the library globals are not installed', function() {
+            Globals.uninstall();
             expect(Globals.host).to.be.null;
         });
 
-        it('should reflect the host object immediately after library globals are intalled', function() {
+        it('should reflect the host object when library globals are intalled', function() {
             Globals.install(window, document);
             expect(Globals.host).to.equals(window);
-        });
-
-        it('should be null immediately after library globals are uninstalled', function() {
-            expect(Globals.host).to.be.null;
         });
     });
 
     describe('.root', function() {
-        beforeEach(function() {
+        it('should be null when the library globals are not installed', function() {
             Globals.uninstall();
-        });
-
-        it('should be null until library globals are installed', function() {
             expect(Globals.root).to.be.null;
         });
 
-        it('should reflect the root object immediately after library globals are intalled', function() {
+        it('should reflect the root object when library globals are intalled', function() {
             Globals.install(window, document);
             expect(Globals.root).to.equals(document);
-        });
-
-        it('should be null immediately after library globals are uninstalled', function() {
-            expect(Globals.root).to.be.null;
         });
     });
 
     describe('.onInstall(callback)', function() {
-        beforeEach(function() {
-            Globals.uninstall();
-        });
 
         it('should register a callback that gets executed once library globals are installed', function() {
             let called = false;
+            Globals.uninstall();
             Globals.onInstall(function() {
                 called = true;
             });
@@ -118,7 +100,6 @@ describe('Globals', function() {
 
         it('should execute the callback immediately if library globals are already installed', function() {
             let called = false;
-            Globals.install(window, document); //install it
             Globals.onInstall(function() {
                 called = true;
             });
@@ -133,7 +114,7 @@ describe('Globals', function() {
     });
 
     describe('.onUninstall(callback)', function() {
-        beforeEach(function() {
+        after(function() {
             Globals.install(window, document);
         });
 
@@ -148,7 +129,6 @@ describe('Globals', function() {
 
         it('should execute the callback immediately if library globals are not installed', function() {
             let called = false;
-            Globals.uninstall(); //uninstall it
             Globals.onUninstall(function() {
                 called = true;
             });

--- a/test/modules/Globals.spec.js
+++ b/test/modules/Globals.spec.js
@@ -31,7 +31,7 @@ describe('Globals', function() {
             expect(called).to.be.true;
         });
 
-        it('should do nothing if library globals is already installed', function() {
+        it('should do nothing if library globals are already installed', function() {
             expect(Globals.install(window, document)).to.be.true;
             expect(Globals.install(window, document)).to.be.false;
         });

--- a/test/modules/Queue.spec.js
+++ b/test/modules/Queue.spec.js
@@ -347,7 +347,7 @@ describe('Queue module', function() {
     });
 
     describe('#screen(item)', function() {
-        it(`it should guard the queue and screen out null and undefined values before they
+        it(`should guard the queue and screen out null and undefined values before they
         are put into the queue`, function() {
             expect((new Queue([null, undefined, 1, 'hey'], true)).items).to.deep.equals([1, 'hey']);
         });

--- a/test/modules/XML.spec.js
+++ b/test/modules/XML.spec.js
@@ -35,7 +35,7 @@ describe('XML module', function() {
     });
 
     describe('.ieString', function() {
-        it(`it should hold the MSXML version string used in creating the request if the
+        it(`should hold the MSXML version string used in creating the request if the
         environment is running in a trident engine that implements XML through ActiveXObject`, function() {
             expect(XML.ieString).to.be.a('string');
         });
@@ -66,12 +66,12 @@ describe('XML module', function() {
     });
 
     describe('#load(url)', function() {
-        it(`it should fetch and load the xml resource from the given url and return a promise`, function() {
+        it(`should fetch and load the xml resource from the given url and return a promise`, function() {
             let xml = new XML();
             expect(xml.load('test/helpers/correct.xml')).to.be.a('Promise');
         });
 
-        it(`it should resolve and pass in the resulting xml document as the resolver argument if the
+        it(`should resolve and pass in the resulting xml document as the resolver argument if the
         xml resource was parsed successfully`, function() {
             let xml = new XML();
             return xml.load('test/helpers/correct.xml').then(xmlDoc => {
@@ -79,7 +79,7 @@ describe('XML module', function() {
             });
         });
 
-        it(`it should reject and pass in the resulting erronous xml document as the rejector argument if the
+        it(`should reject and pass in the resulting erronous xml document as the rejector argument if the
         xml resource could not be loaded or could not be parsed successfully`, function() {
             let xml = new XML('root');
             return xml.load('test/helpers/erronous.xml').catch(xmlDoc => {
@@ -87,7 +87,7 @@ describe('XML module', function() {
             });
         });
 
-        it(`it should reject if error occured while fetching resource`, function() {
+        it(`should reject if error occured while fetching resource`, function() {
             let xml = new XML();
             return xml.load('test/helpers/unexisting.xml').catch(xmlDoc => {
                 expect(xmlDoc.parseError.errorCode).to.be.greaterThan(0);
@@ -96,7 +96,7 @@ describe('XML module', function() {
     });
 
     describe('#loadXML(xmlString)', function() {
-        it(`it should parse and load the given xml string and return a promise`, function() {
+        it(`should parse and load the given xml string and return a promise`, function() {
             let xmlString = `
                 <?xml version="1.0" encoding="utf-8" ?>
                 <students>
@@ -117,7 +117,7 @@ describe('XML module', function() {
             expect(xml.loadXML(xmlString)).to.be.a('Promise');
         });
 
-        it(`it should resolve and pass in the resulting xml document as the resolver argument if the
+        it(`should resolve and pass in the resulting xml document as the resolver argument if the
         xmlString was parsed successfully`, function() {
             let xmlString = `
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -141,7 +141,7 @@ describe('XML module', function() {
             });
         });
 
-        it(`it should reject and pass in the resulting erronous xml document as the rejector argument if the
+        it(`should reject and pass in the resulting erronous xml document as the rejector argument if the
         xml resource could not be parsed successfully`, function() {
             let xmlString = `
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -169,7 +169,7 @@ describe('XML module', function() {
     });
 
     describe('#document', function() {
-        it(`it should hold the xml document`, function() {
+        it(`should hold the xml document`, function() {
             expect(new XML().document.nodeType).to.be.equals(9);
         });
     });

--- a/test/modules/XPath.spec.js
+++ b/test/modules/XPath.spec.js
@@ -105,4 +105,33 @@ describe('XPath module', function() {
             }).to.throw(TypeError);
         });
     });
+
+    describe('.selectNodes(selector, node, namespaces)', function() {
+        it(`it should select and return an array of all matching nodes, given xPath selector,
+        under the given node context`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectNodes('students/student/name', xmlDoc))
+                    .to.be.lengthOf(2).and.to.satisfy(items => {
+                        return items[0].text === 'Harrison Ifeanyichukwu' &&
+                            items[1].text === 'Helen Brown';
+                    });
+            });
+        });
+    });
 });

--- a/test/modules/XPath.spec.js
+++ b/test/modules/XPath.spec.js
@@ -36,13 +36,13 @@ describe('XPath module', function() {
     });
 
     describe('.implementation', function() {
-        it(`it should hold an integer that indicates the XPath implementation type`, function() {
+        it(`should hold an integer that indicates the XPath implementation type`, function() {
             expect(XPath.implementation).to.equals(2);
         });
     });
 
     describe('.selectNode(selector, node, namespaces)', function() {
-        it(`it should select the first node that matches the given xPath selector, under the given
+        it(`should select the first node that matches the given xPath selector, under the given
         node context`, function() {
             let xmlString = `
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -93,6 +93,28 @@ describe('XPath module', function() {
             });
         });
 
+        it(`should return null if no result is found`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectNode('students/student/age', xmlDoc)).to.be.null;
+            });
+        });
+
         it(`should throw error if argument one is not a selector string`, function() {
             expect(function() {
                 XPath.selectNode(null);
@@ -107,7 +129,7 @@ describe('XPath module', function() {
     });
 
     describe('.selectNodes(selector, node, namespaces)', function() {
-        it(`it should select and return an array of all matching nodes, given xPath selector,
+        it(`should select and return an array of all matching nodes, given xPath selector,
         under the given node context`, function() {
             let xmlString = `
                 <?xml version="1.0" encoding="utf-8" ?>
@@ -131,6 +153,76 @@ describe('XPath module', function() {
                         return items[0].text === 'Harrison Ifeanyichukwu' &&
                             items[1].text === 'Helen Brown';
                     });
+            });
+        });
+
+        it(`should return empty array if no result is found`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectNodes('students/student/age', xmlDoc)).to.be.an('Array')
+                    .and.lengthOf(0);
+            });
+        });
+    });
+
+    describe('.selectAltNode(selector, node, namespaces)', function() {
+        it(`should select the first node that matches a list of alternate xPath selectors
+        separated using double pipe (||), under the given node context`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectAltNode('//age || //name', xmlDoc).text).to.equals('Harrison Ifeanyichukwu');
+            });
+        });
+
+        it(`should return null if no alternate selector matches a node`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectAltNode('//age || //height', xmlDoc)).to.be.null;
             });
         });
     });

--- a/test/modules/XPath.spec.js
+++ b/test/modules/XPath.spec.js
@@ -1,0 +1,108 @@
+import XPath from './../../src/modules/XPath.js';
+import XML from '../../src/modules/XML.js';
+
+describe('XPath module', function() {
+    //start up server in node.js environment before any test begins
+    before(function() {
+        if (typeof server !== 'undefined') {
+            server.listen();
+        }
+    });
+
+    //close up server in node.js environment after running tests
+    after(function() {
+        if (typeof server !== 'undefined') {
+            server.close();
+        }
+    });
+
+    describe('.install(hostParam, rootParam)', function() {
+        it('should call the global install method with the given parameter', function() {
+            expect(XPath.install(window, document)).to.be.false;
+        });
+    });
+
+    describe('.uninstall()', function() {
+        it('should call the global uninstall method', function() {
+            expect(XPath.uninstall()).to.be.true;
+            expect(XPath.install(window, document)).to.be.true;
+        });
+    });
+
+    describe('.supported', function() {
+        it('it should hold a boolean value that indicates if XPath is supported', function() {
+            expect(XPath.supported).to.be.true;
+        });
+    });
+
+    describe('.implementation', function() {
+        it(`it should hold an integer that indicates the XPath implementation type`, function() {
+            expect(XPath.implementation).to.equals(2);
+        });
+    });
+
+    describe('.selectNode(selector, node, namespaces)', function() {
+        it(`it should select the first node that matches the given xPath selector, under the given
+        node context`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectNode('students/student/name', xmlDoc).text).to.equals('Harrison Ifeanyichukwu');
+            });
+        });
+
+        it(`it select the first node that matches the given xPath selector, under the node context
+        using the optional namespaces object`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students xmlns="http://student.org/ns">
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            let namespaces = {st: 'http://student.org/ns'};
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectNode('st:students/st:student/st:name', xmlDoc, namespaces)
+                    .text).to.equals('Harrison Ifeanyichukwu');
+                expect(XPath.selectNode('st:student/st:name', xmlDoc.documentElement, namespaces)
+                    .text).to.equals('Harrison Ifeanyichukwu');
+            });
+        });
+
+        it(`should throw error if argument one is not a selector string`, function() {
+            expect(function() {
+                XPath.selectNode(null);
+            }).to.throw(TypeError);
+        });
+
+        it(`should throw error if argument two is not a document nor element node`, function() {
+            expect(function() {
+                XPath.selectNode('students/student/name', null);
+            }).to.throw(TypeError);
+        });
+    });
+});

--- a/test/modules/XPath.spec.js
+++ b/test/modules/XPath.spec.js
@@ -226,4 +226,56 @@ describe('XPath module', function() {
             });
         });
     });
+
+    describe('.selectAltNodes(selector, node, namespaces)', function() {
+        it(`should return array of node that matches one of the alternate xPath selectors
+        separated using double pipe (||), under the given node context`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectAltNodes('//age || //name', xmlDoc)).to.be.lengthOf(2)
+                    .and.to.satisfy((items) => {
+                        return items[0].text === 'Harrison Ifeanyichukwu'
+                            && items[1].text === 'Helen Brown';
+                    });
+            });
+        });
+
+        it(`should return empty array if no alternate selector matches any node`, function() {
+            let xmlString = `
+                <?xml version="1.0" encoding="utf-8" ?>
+                <students>
+                    <student>
+                        <name>Harrison Ifeanyichukwu</name>
+                        <class>JSS3</class>
+                        <rating>0.7</rating>
+                    </student>
+                    <student>
+                        <name>Helen Brown</name>
+                        <class>JSS3</class>
+                        <rating>0.9</rating>
+                    </student>
+                </students>
+            `;
+
+            return new XML().loadXML(xmlString).then(function(xmlDoc) {
+                expect(XPath.selectAltNodes('//age || //height', xmlDoc)).to.be.an('Array')
+                    .and.lengthOf(0);
+            });
+        });
+    });
 });

--- a/test/modules/Xhr.spec.js
+++ b/test/modules/Xhr.spec.js
@@ -163,7 +163,7 @@ describe('Xhr', function() {
     });
 
     describe('.ieString', function() {
-        it(`it should hold the MSXML version string used in creating the request transport if
+        it(`should hold the MSXML version string used in creating the request transport if
         the environment is running in a trident engine that implements XMLHttpRequest through
         ActiveXObject`, function() {
             expect(Xhr.ieString).to.be.a('string');

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,39 +1,41 @@
 let JSDOM = require('jsdom').JSDOM;
 
-/**
- * create dom to be used for testing
-*/
-let dom = new JSDOM('<!doctype html><html><body></body></html>', {
-    url: 'http://127.0.0.1:4000',
-    pretendToBeVisual: true
-});
+if (typeof global.window === 'undefined') {
+    /**
+     * create dom to be used for testing
+    */
+    let dom = new JSDOM('<!doctype html><html><body></body></html>', {
+        url: 'http://127.0.0.1:4000',
+        pretendToBeVisual: true
+    });
 
-/**
- * set up test global variables including a test server to be used for http requests
-*/
-global.expect = require('chai').expect;
-global.server = require('../server/app.js');
-global.window = dom.window;
-global.document = window.document;
+    /**
+     * set up test global variables including a test server to be used for http requests
+    */
+    global.expect = require('chai').expect;
+    global.server = require('../server/app.js');
+    global.window = dom.window;
+    global.document = window.document;
 
-window.XMLSerializer = require('@harrison-ifeanyichukwu/xml-serializer');
+    window.XMLSerializer = require('@harrison-ifeanyichukwu/xml-serializer');
 
-require('wicked-good-xpath').install(window, true);
+    require('wicked-good-xpath').install(window, true);
 
-/**
- * a workaround to istanbul's branching error on constructors that extends other constructors.
-*/
-global.getInstance = function(className, ...parameters) {
-    let proto = className.__proto__;
+    /**
+     * a workaround to istanbul's branching error on constructors that extends other constructors.
+    */
+    global.getInstance = function(className, ...parameters) {
+        let proto = className.__proto__;
 
-    className.__proto__ = null;
-    try {
-        new className(...parameters);
-    }
-    catch(ex) {
-        //
-    }
+        className.__proto__ = null;
+        try {
+            new className(...parameters);
+        }
+        catch(ex) {
+            //
+        }
 
-    Object.setPrototypeOf(className, proto);
-    return new className(...parameters);
-};
+        Object.setPrototypeOf(className, proto);
+        return new className(...parameters);
+    };
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -18,6 +18,8 @@ global.document = window.document;
 
 window.XMLSerializer = require('@harrison-ifeanyichukwu/xml-serializer');
 
+require('wicked-good-xpath').install(window, true);
+
 /**
  * a workaround to istanbul's branching error on constructors that extends other constructors.
 */


### PR DESCRIPTION
The `XPath` module provides interface for running xpath selection on a given valid `xml` node with support for namespacing. It  unifies IE ActiveXObject `selectNode`, `selectNodes`, & domimplementations `document.evaluate` methods.

**Usage example**

```javascript
import {XML, XPath} from 'forensic-js';

let xmlString = `
    <?xml version="1.0" encoding="utf-8" ?>
    <students xmlns="http://student.org/ns">
        <student>
            <name>Harrison Ifeanyichukwu</name>
            <class>JSS3</class>
            <rating>0.7</rating>
        </student>
        <student>
            <name>Helen Brown</name>
            <class>JSS3</class>
            <rating>0.9</rating>
        </student>
    </students>
`;

let namespaces = {
    st: 'http://student.org/ns'
};

let xmlDoc = new XML().loadXML(xmlString);

//run selection from the document context
XPath.selectNode('st:students/st:student/st:name', xmlDoc, namespaces);

//run selection from the documentElement context
XPath.selectNodes('st:students/st:student/st:name', xmlDoc.documentElement, namespaces);
```